### PR TITLE
Support for source fields using comma separators

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,7 @@ const valueFormatters: ValueFormatters = {
   iconImage: extractImageUrl,
   houseImage: extractImageUrl,
   inventoryImage: extractImageUrl,
+  photoImage: extractImageUrl,
   uses: normaliseUse,
   source: (input: string) =>
     input.includes('\n')

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,7 @@ const valueFormatters: ValueFormatters = {
   source: (input: string) =>
     input.includes('\n')
       ? input.split('\n')
-      : input.split(';').map(i => i.trim()),
+      : input.split(/[;,]/).map(i => i.trim()),
   birthday: normaliseBirthday,
 };
 


### PR DESCRIPTION
The literal value for e.g. `"Agent K.K."` is now `"K.K. concert, Nook Shopping Catalog"`.

Also added support for parsing the `photoImage` field added to villagers.